### PR TITLE
Update webpack.config.js to remove warning messages do to the use of Angular 5

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,6 +74,7 @@ module.exports = {
       name: 'common',
       minChunks: module => module.context && module.context.indexOf('node_modules') !== -1
     }),
+    new webpack.ContextReplacementPlugin(/\@angular(\\|\/)core(\\|\/)esm5/, path.join(__dirname, './src')),
   ],
 };
 


### PR DESCRIPTION
Update webpack to avoid warnings thrown by Angular 5 , when starting project.
Issue extracted from : https://github.com/angular/angular/issues/20357
 
This is the warning that we are getting:
WARNING in ./node_modules/@angular/core/esm5/core.js
6581:15-36 Critical dependency: the request of a dependency is an expression
 @ ./node_modules/@angular/core/esm5/core.js
 @ ./node_modules/@angular/platform-browser-dynamic/esm5/platform-browser-dynamic.js
 @ ./src/angular2/angular2.app.js
 @ ./src/single-spa-examples.js
 @ multi (webpack)-dev-server/client?http://localhost:8080 ./src/single-spa-examples.js