### PR TITLE
Adding error handling for enableProdMode.

### DIFF
--- a/src/angular2/main-module.ts
+++ b/src/angular2/main-module.ts
@@ -3,12 +3,16 @@ import {BrowserModule} from '@angular/platform-browser';
 import {ExampleNg2App} from './example-ng2-app.component.ts';
 import {enableProdMode} from '@angular/core';
 
-enableProdMode()
+try {
+    enableProdMode();
+} catch (err) {
+    console.info('EnableProdMode already set')
+}
 
 @NgModule({
-  imports: [BrowserModule],
-  declarations: [ExampleNg2App],
-  bootstrap: [ExampleNg2App]
+    imports: [BrowserModule],
+    declarations: [ExampleNg2App],
+    bootstrap: [ExampleNg2App]
 })
 export default class MainModule {
 }


### PR DESCRIPTION
If we use more than one Angular App that tries to enable prod mode,
this will lead us to an Uncaught Error