### PR TITLE
fix broken huge-apps link

### DIFF
--- a/src/react/components/Dashboard.js
+++ b/src/react/components/Dashboard.js
@@ -9,7 +9,7 @@ class Dashboard extends Component {
       <div>
         <h2>React + react-router</h2>
         <p>
-          This is the react-router <a href="https://github.com/ReactTraining/react-router/tree/master/examples/huge-apps" target="_blank">huge-apps example</a>,
+          This is the react-router <a href="https://github.com/ReactTraining/react-router/tree/1.0.x/examples/huge-apps" target="_blank">huge-apps example</a>,
           converted into a single-spa application. Note that the entire application is lazy loaded (single-spa's does this)
       and that each of the individual react-router routes is lazy loaded (react-router's does this).
         </p>


### PR DESCRIPTION
This PR fixes a link in the react example. It needed to point to an older react-router branch as the master branch no longer includes examples. See #58.