### PR TITLE
fix side nav that doesn't display

### DIFF
--- a/src/navbar/navbar.component.js
+++ b/src/navbar/navbar.component.js
@@ -37,14 +37,12 @@ export default class Navbar extends React.Component {
               <ul className="right hide-on-med-and-down">
                 {menuItems.call(this)}
               </ul>
-              <Dialog dialogId="sideNav">
-                <ul className="side-nav" id="mobile-demo">
-                  {menuItems.call(this)}
-                </ul>
-              </Dialog>
             </div>
           </nav>
         </div>
+        <ul className="side-nav" id="mobile-demo">
+          {menuItems.call(this)}
+        </ul>
       </div>
     );
   }


### PR DESCRIPTION
This PR fixes the side nav on small screen sizes. I don't know much about materialize, but I'm assuming that the side nav init function only works if your target list is a direct child of one of the parents of the toggle button. I moved the list outside of the `Dialog` component and it works now. 

I'm not sure if this will have some unintended side effects as I am not very familiar with this project and I don't know all of the reasons behind using the `Dialog` component, but I did test it locally and everything seems to be working.

see #60 